### PR TITLE
fix sonar properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,3 +9,4 @@ sonar.tests=src
 sonar.test.inclusions=**/tests/**/test_*.py
 
 sonar.python.coverage.reportPaths=coverage.xml
+sonar.python.version=3.12


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Specify the Python version as 3.12 in the SonarQube properties to ensure compatibility.